### PR TITLE
take only tagged parent models

### DIFF
--- a/fast_bi_dbt_runner/utils.py
+++ b/fast_bi_dbt_runner/utils.py
@@ -214,7 +214,9 @@ def get_tagged_models(manifest_data, relatives_map, dbt_tag):
     tagged_models = list(filtered_tasks.keys())
     result = set(tagged_models)
     for model in tagged_models:
-        collect_relatives(manifest_data, model, relatives_map, result)
+        collect_relatives(manifest_data, model, relatives_map, result) 
+    # Only include nodes that have one of the requested tags (exclude ancestors/descendants without the tag)
+    result = {node_id for node_id in result if any(tag in manifest_data[node_id].get("tags", []) for tag in dbt_tag)}
     return {node_id: manifest_data[node_id] for node_id in result}
 
 


### PR DESCRIPTION
When loading the dbt manifest with tag-based filtering and dbt_tag_ancestors or dbt_tag_descendants enabled, the runner was including all ancestors or descendants of tagged models, even when those relatives did not have the requested tag. This change restricts the selected set to only nodes that have one of the requested tags.
