### PR TITLE
update import PythonOperator

### DIFF
--- a/fast_bi_dbt_runner/airbyte_task_group_builder.py
+++ b/fast_bi_dbt_runner/airbyte_task_group_builder.py
@@ -6,8 +6,11 @@ import requests
 from airflow.hooks.base import BaseHook
 from airflow.operators.empty import EmptyOperator
 from airflow.operators.python import BranchPythonOperator
-from airflow.operators.python_operator import PythonOperator
 from airflow.utils.task_group import TaskGroup
+try:
+    from airflow.operators.python import PythonOperator
+except ImportError:
+    from airflow.operators.python_operator import PythonOperator
 
 
 def get_con_info(conn, api, ti=None):


### PR DESCRIPTION
updated deprecated Airflow imports (e.g. python_operator) to new module paths required for Airflow 3.0 compatibility.